### PR TITLE
Update guzzle6 adapater with httplug new contract

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,6 @@ cache:
     - $HOME/.composer/cache
 
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
@@ -20,9 +19,10 @@ env:
 matrix:
   allow_failures:
     - php: 7.0
+    - php: hhvm
   fast_finish: true
   include:
-    - php: 5.4
+    - php: 5.5
       env: COMPOSER_FLAGS="--prefer-stable --prefer-lowest" COVERAGE=true TEST_COMMAND="composer test-ci"
 
 before_install:

--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,22 @@
         }
     ],
     "require": {
-        "php": ">=5.4",
+        "php": ">=5.5.0",
         "php-http/httplug": "^1.0@dev",
+        "php-http/utils": "^0.1@dev",
         "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {
         "ext-curl": "*",
-        "php-http/adapter-integration-tests": "^0.1"
+        "php-http/message-factory": "dev-master as 0.1.1",
+        "php-http/adapter-integration-tests": "dev-feature/httplug"
     },
+    "repositories": [
+        {
+            "type": "vcs",
+            "url": "https://github.com/joelwurtz/adapter-integration-tests"
+        }
+    ],
     "provide": {
         "php-http/client-implementation": "1.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -22,15 +22,8 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "php-http/message-factory": "dev-master as 0.1.1",
-        "php-http/adapter-integration-tests": "dev-feature/httplug"
+        "php-http/adapter-integration-tests": "^0.2@dev"
     },
-    "repositories": [
-        {
-            "type": "vcs",
-            "url": "https://github.com/joelwurtz/adapter-integration-tests"
-        }
-    ],
     "provide": {
         "php-http/client-implementation": "1.0"
     },

--- a/tests/Guzzle6HttpAdapterTest.php
+++ b/tests/Guzzle6HttpAdapterTest.php
@@ -19,11 +19,6 @@ use Http\Adapter\Guzzle6HttpAdapter;
  */
 abstract class Guzzle6HttpAdapterTest extends HttpAdapterTest
 {
-    public function testGetName()
-    {
-        $this->assertSame('guzzle6', $this->httpAdapter->getName());
-    }
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
I update the guzzle6 adapter to work with the new contract of Httplug, all tests are green.

For the sendRequests method after viewing the guzzle implementation and discussing it with @sagikazarmark on Slack, we concluded there was no real benefits to wrap the Guzzle object as it does not store requests, responses or exceptions objects.