### PR TITLE
improve promise exception

### DIFF
--- a/src/Guzzle6Promise.php
+++ b/src/Guzzle6Promise.php
@@ -63,7 +63,7 @@ class Guzzle6Promise implements Promise
             }
 
             if (!($reason instanceof GuzzleExceptions\GuzzleException)) {
-                throw new \RuntimeException("Invalid reason");
+                throw new \RuntimeException("Invalid exception returned from Guzzle6", $reason);
             }
 
             $this->state     = self::REJECTED;


### PR DESCRIPTION
if the exception stays, we really should keep the nested exception or this will be very annoying to debug.