### PR TITLE
Move tests to global Tests namespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -35,7 +35,7 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Http\\Adapter\\Guzzle6\\Tests\\": "tests/"
+            "Tests\\Http\\Adapter\\Guzzle6\\": "tests/"
         }
     },
     "scripts": {

--- a/tests/CurlHttpAdapterTest.php
+++ b/tests/CurlHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Adapter\Guzzle6\Tests;
+namespace Tests\Http\Adapter\Guzzle6;
 
 use GuzzleHttp\Handler\CurlHandler;
 

--- a/tests/CurlHttpAsyncAdapterTest.php
+++ b/tests/CurlHttpAsyncAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Adapter\Guzzle6\Tests;
+namespace Tests\Http\Adapter\Guzzle6;
 
 use GuzzleHttp\Handler\CurlHandler;
 

--- a/tests/HttpAdapterTest.php
+++ b/tests/HttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Adapter\Guzzle6\Tests;
+namespace Tests\Http\Adapter\Guzzle6;
 
 use GuzzleHttp\Client as GuzzleClient;
 use Http\Adapter\Guzzle6\Client;

--- a/tests/HttpAsyncAdapterTest.php
+++ b/tests/HttpAsyncAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Adapter\Guzzle6\Tests;
+namespace Tests\Http\Adapter\Guzzle6;
 
 use GuzzleHttp\Client as GuzzleClient;
 use Http\Adapter\Guzzle6\Client;

--- a/tests/MultiCurlHttpAdapterTest.php
+++ b/tests/MultiCurlHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Adapter\Guzzle6\Tests;
+namespace Tests\Http\Adapter\Guzzle6;
 
 use GuzzleHttp\Handler\CurlMultiHandler;
 

--- a/tests/MultiCurlHttpAsyncAdapterTest.php
+++ b/tests/MultiCurlHttpAsyncAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Adapter\Guzzle6\Tests;
+namespace Tests\Http\Adapter\Guzzle6;
 
 use GuzzleHttp\Handler\CurlMultiHandler;
 

--- a/tests/PromiseExceptionTest.php
+++ b/tests/PromiseExceptionTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Adapter\Guzzle6\Tests;
+namespace Tests\Http\Adapter\Guzzle6;
 
 use GuzzleHttp\Exception as GuzzleExceptions;
 use Http\Adapter\Guzzle6\Promise;

--- a/tests/PromiseExceptionTest.php
+++ b/tests/PromiseExceptionTest.php
@@ -10,7 +10,10 @@ use Http\Adapter\Guzzle6\Promise;
  */
 class PromiseExceptionTest extends \PHPUnit_Framework_TestCase
 {
-    public function testGetException()
+    /**
+     * @test
+     */
+    public function it_converts_guzzle_exceptions_to_domain_exceptions()
     {
         $request = $this->getMock('Psr\Http\Message\RequestInterface');
         $response = $this->getMock('Psr\Http\Message\ResponseInterface');

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -13,8 +13,9 @@ class PromiseTest extends \PHPUnit_Framework_TestCase
 {
     /**
      * @expectedException \Exception
+     * @test
      */
-    public function testNonDomainExceptionIsHandled()
+    public function it_handles_non_domain_exception()
     {
         $request = $this->prophesize('Psr\Http\Message\RequestInterface');
         $promise = new RejectedPromise(new \Exception());

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Adapter\Guzzle6\Tests;
+namespace Tests\Http\Adapter\Guzzle6;
 
 use GuzzleHttp\Exception as GuzzleExceptions;
 use GuzzleHttp\Promise\RejectedPromise;

--- a/tests/StreamHttpAdapterTest.php
+++ b/tests/StreamHttpAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Adapter\Guzzle6\Tests;
+namespace Tests\Http\Adapter\Guzzle6;
 
 use GuzzleHttp\Handler\StreamHandler;
 

--- a/tests/StreamHttpAsyncAdapterTest.php
+++ b/tests/StreamHttpAsyncAdapterTest.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Http\Adapter\Guzzle6\Tests;
+namespace Tests\Http\Adapter\Guzzle6;
 
 use GuzzleHttp\Handler\StreamHandler;
 


### PR DESCRIPTION
This PR brings tests closer to spec tests:

- Namespace starts with `Tests\` instead of the usual PSR-4 autoloading standard. This is good because the rest of the namespace is not separated into parts because of the `Tests\` namespace inserted in the middle. (For example `Tests\Http\Adapter\GuzzleTest` instead of `Http\Adapter\Tests\GuzzleTest`
- Tests are rewritten in phpspec style: `it_does_something`. (`@test` annotation added)