### PR TITLE
Add php-http/promise to the list of dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": ">=5.5.0",
         "php-http/httplug": "^1.0",
+        "php-http/promise": "^1.0",
         "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {


### PR DESCRIPTION
We should have the `php-http/promise` as a dependency since we are using it. 

I know that `php-http/promise` is an indirect dependency thanks to `php-http/httplug` but we should specify our dependencies directly. 