### PR TITLE
Add default empty config value for Client::buildClient

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -73,7 +73,7 @@ class Client implements HttpClient, HttpAsyncClient
      *
      * @return GuzzleClient
      */
-    private static function buildClient(array $config)
+    private static function buildClient(array $config = array())
     {
         $handlerStack = new HandlerStack(\GuzzleHttp\choose_handler());
         $handlerStack->push(Middleware::prepareBody(), 'prepare_body');


### PR DESCRIPTION
There is an issue when we create new Client object with no parameters: constructor calls Client::buildClient method without params too, and it fails because it has one required parameter. It may be walked around by using Client::createWithConfig method with an empty config, but it will be cool if it will work natural way with constructor too