### PR TITLE
add test for default constructor

### DIFF
--- a/tests/DefaultHttpAdapterTest.php
+++ b/tests/DefaultHttpAdapterTest.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Http\Adapter\Guzzle6\Tests;
+
+use Http\Adapter\Guzzle6\Client;
+use Http\Client\Tests\HttpClientTest;
+
+/**
+ * @author David Buchmann <mail@davidbu.ch>
+ */
+class DefaultHttpAdapterTest extends HttpClientTest
+{
+    /**
+     * {@inheritdoc}
+     */
+    protected function createHttpAdapter()
+    {
+        return new Client();
+    }
+}


### PR DESCRIPTION
#31 was a regression that went undetected because we where missing this test, see also #32.

this test will prevent the problem from coming up again.