### PR TITLE
PHPUnit 6 compatability

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "php-http/client-integration-tests": "^0.5.1"
+        "php-http/client-integration-tests": "^0.6"
     },
     "provide": {
         "php-http/client-implementation": "1.0",

--- a/tests/PromiseExceptionTest.php
+++ b/tests/PromiseExceptionTest.php
@@ -4,11 +4,12 @@ namespace Http\Adapter\Guzzle6\Tests;
 
 use GuzzleHttp\Exception as GuzzleExceptions;
 use Http\Adapter\Guzzle6\Promise;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Tobias Nyholm <tobias.nyholm@gmail.com>
  */
-class PromiseExceptionTest extends \PHPUnit_Framework_TestCase
+class PromiseExceptionTest extends TestCase
 {
     public function testGetException()
     {

--- a/tests/PromiseTest.php
+++ b/tests/PromiseTest.php
@@ -4,11 +4,12 @@ namespace Http\Adapter\Guzzle6\Tests;
 
 use GuzzleHttp\Promise\RejectedPromise;
 use Http\Adapter\Guzzle6\Promise;
+use PHPUnit\Framework\TestCase;
 
 /**
  * @author Márk Sági-Kazár <mark.sagikazar@gmail.com>
  */
-class PromiseTest extends \PHPUnit_Framework_TestCase
+class PromiseTest extends TestCase
 {
     /**
      * @expectedException \Exception


### PR DESCRIPTION
This will allow use to use phpunit 6. Older versions are still supported. 

This will allow the integration tests repo to run Guzzle6 tests on travis. 