### PR TITLE
Fix provide http client

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
         "php-http/client-integration-tests": "^0.6"
     },
     "provide": {
-        "php-http/client-implementation": "1.0",
+        "php-http/client-common": "1.0",
         "php-http/async-client-implementation": "1.0"
     },
     "autoload": {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | yes
| Deprecations?   | no
| Related tickets | X
| Documentation   | if this is a new feature, link to pull request in https://github.com/php-http/documentation that adds relevant documentation
| License         | MIT


#### What's in this PR?

Change provide PHP-HTTP version


#### Why?

php-http/client-implementation repository has been renamed to php-http/client-common. In order not to mislead anyone, it needs to be updated
