### PR TITLE
Make this client adapter compatible with PSR18.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "php-http/client-integration-tests": "dev-master"
+        "php-http/client-integration-tests": "^2.0"
     },
     "provide": {
         "php-http/client-implementation": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -25,7 +25,7 @@
     },
     "provide": {
         "php-http/client-implementation": "1.0",
-        "php-http/async-client-implementation": "1.0"
+        "php-http/async-client-implementation": "1.0",
         "psr/http-client-implementation": "1.0"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
     },
     "require-dev": {
         "ext-curl": "*",
-        "php-http/client-integration-tests": "^0.6"
+        "php-http/client-integration-tests": "dev-master"
     },
     "provide": {
         "php-http/client-implementation": "1.0",

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "php-http/httplug": "^1.0",
+        "php-http/httplug": "^2.0@dev",
         "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     ],
     "require": {
         "php": "^7.1",
-        "php-http/httplug": "^2.0@dev",
+        "php-http/httplug": "^2.0",
         "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -26,6 +26,7 @@
     "provide": {
         "php-http/client-implementation": "1.0",
         "php-http/async-client-implementation": "1.0"
+        "psr/http-client-implementation": "1.0"
     },
     "autoload": {
         "psr-4": {

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
     "require": {
         "php": "^7.1",
         "php-http/httplug": "^2.0",
+        "psr/http-client": "^1.0",
         "guzzlehttp/guzzle": "^6.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "1.2-dev"
+            "dev-master": "2.x-dev"
         }
     }
 }

--- a/src/Client.php
+++ b/src/Client.php
@@ -9,6 +9,7 @@ use GuzzleHttp\Middleware;
 use Http\Client\HttpAsyncClient;
 use Http\Client\HttpClient;
 use Psr\Http\Message\RequestInterface;
+use Psr\Http\Message\ResponseInterface;
 
 /**
  * HTTP Adapter for Guzzle 6.
@@ -49,7 +50,7 @@ final class Client implements HttpClient, HttpAsyncClient
     /**
      * {@inheritdoc}
      */
-    public function sendRequest(RequestInterface $request)
+    public function sendRequest(RequestInterface $request): ResponseInterface
     {
         $promise = $this->sendAsyncRequest($request);
 


### PR DESCRIPTION
This simple PR (and test fixes) will be the only change to make us compatible with PSR18, right?

#### TODO

- [x] Fix the tests. Make sure we can install php-http/client-integration-tests
- [x] Maybe require PSR-18 explicity
- [x] Show that we `provide` psr-18. 

FYI @fbourigault 