### PR TITLE
Rewrote PromiseExceptionTests

### DIFF
--- a/src/Promise.php
+++ b/src/Promise.php
@@ -61,10 +61,10 @@ final class Promise implements HttpPromise
                 $this->exception = $reason;
             } elseif ($reason instanceof GuzzleExceptions\GuzzleException) {
                 $this->exception = $this->handleException($reason, $request);
-            } elseif ($reason instanceof \Exception) {
+            } elseif ($reason instanceof \Throwable) {
                 $this->exception = new \RuntimeException('Invalid exception returned from Guzzle6', 0, $reason);
             } else {
-                $this->exception = new \UnexpectedValueException('Reason returned from Guzzle6 must be an Exception', 0, $reason);
+                $this->exception = new \UnexpectedValueException('Reason returned from Guzzle6 must be an Exception');
             }
 
             throw $this->exception;

--- a/tests/PromiseExceptionTest.php
+++ b/tests/PromiseExceptionTest.php
@@ -5,7 +5,6 @@ declare(strict_types=1);
 namespace Http\Adapter\Guzzle6\Tests;
 
 use GuzzleHttp\Exception as GuzzleExceptions;
-use GuzzleHttp\Promise\PromiseInterface;
 use Http\Adapter\Guzzle6\Promise;
 use Http\Client\Exception\HttpException;
 use Http\Client\Exception\NetworkException;

--- a/tests/PromiseExceptionTest.php
+++ b/tests/PromiseExceptionTest.php
@@ -22,9 +22,6 @@ use Psr\Http\Message\ResponseInterface;
 final class PromiseExceptionTest extends TestCase
 {
     /**
-     * @param RequestInterface $request
-     * @param \Exception $guzzleException
-     * @param string $adapterExceptionClass
      * @dataProvider exceptionThatIsThrownForGuzzleExceptionProvider
      */
     public function testExceptionThatIsThrownForGuzzleException(

--- a/tests/PromiseExceptionTest.php
+++ b/tests/PromiseExceptionTest.php
@@ -25,14 +25,13 @@ final class PromiseExceptionTest extends TestCase
      */
     public function testExceptionThatIsThrownForGuzzleException(
         RequestInterface $request,
-        \Exception $guzzleException,
+        $reason,
         string $adapterExceptionClass
     ) {
         $guzzlePromise = new \GuzzleHttp\Promise\Promise();
-        $guzzlePromise->reject($guzzleException);
+        $guzzlePromise->reject($reason);
         $promise = new Promise($guzzlePromise, $request);
         $this->expectException($adapterExceptionClass);
-        $this->expectExceptionMessage('foo');
         $promise->wait();
     }
 
@@ -54,6 +53,10 @@ final class PromiseExceptionTest extends TestCase
             [$request, new GuzzleExceptions\BadResponseException('foo', $request), RequestException::class],
             [$request, new GuzzleExceptions\ClientException('foo', $request), RequestException::class],
             [$request, new GuzzleExceptions\ServerException('foo', $request), RequestException::class],
+            // Non PSR-18 Exceptions thrown
+            [$request, new \Exception('foo'), \RuntimeException::class],
+            [$request, new \Error('foo'), \RuntimeException::class],
+            [$request, 'whatever', \UnexpectedValueException::class],
         ];
     }
 }


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT

#### What's in this PR?

Rewrote the tests of PromiseExceptionTest class.

#### Why?

- Each test now has each own separate test case.
- Sweetened the syntax/codestyle by using the `class` constant.
- Tests previously where using reflection in order to check a private method. Private methods are not to be tested. Private methods exist as servants of the public methods. In the way it was before it makes the refactoring harder. The reason is that if I change the private function and what it does I must not alter my tests as long as the public function still works as expected.
- Reflection is just slow.
- Used more actual objects instead of mocks. Using actual objects tests even more thorough your application/library. 
