### PR TITLE
Remove wrong docblock that says that PHP5 is required

### DIFF
--- a/tests/CurlHttpAdapterTest.php
+++ b/tests/CurlHttpAdapterTest.php
@@ -5,8 +5,6 @@ namespace Http\Adapter\Guzzle6\Tests;
 use GuzzleHttp\Handler\CurlHandler;
 
 /**
- * @requires PHP 5.5
- *
  * @author GeLo <geloen.eric@gmail.com>
  */
 class CurlHttpAdapterTest extends HttpAdapterTest

--- a/tests/CurlHttpAsyncAdapterTest.php
+++ b/tests/CurlHttpAsyncAdapterTest.php
@@ -5,8 +5,6 @@ namespace Http\Adapter\Guzzle6\Tests;
 use GuzzleHttp\Handler\CurlHandler;
 
 /**
- * @requires PHP 5.5
- *
  * @author Joel Wurtz <joel.wurtz@gmail.com>
  */
 class CurlHttpAsyncAdapterTest extends HttpAsyncAdapterTest


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| License         | MIT


#### What's in this PR?

I removed the annotation to check if they affect in anyway or if they were there for just information reasons.

If they were effective then it should have been fixed.