### PR TITLE
explain in phpdoc that guzzle instance must not throw exceptions

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -25,6 +25,11 @@ final class Client implements HttpClient, HttpAsyncClient
      */
     private $client;
 
+    /**
+     * If you pass a Guzzle instance as $client, make sure to configure Guzzle to not
+     * throw exceptions on HTTP error status codes, or this adapter will violate PSR-18.
+     * See also self::buildClient at the bottom of this class.
+     */
     public function __construct(?ClientInterface $client = null)
     {
         if (!$client) {


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | fixes #61 
| Documentation   | -
| License         | MIT


#### What's in this PR?

Add phpdoc to explain guzzle argument


#### Why?

Its not obvious for the user that passing a default guzzle instance will make the adapter violate PSR-18.
