### PR TITLE
Update to support PHP 7.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
+## [2.0.2] - 2019-08-01
+
+### Added
+
+- Support for PHP 7.0
 
 ## [2.0.1] - 2018-12-16
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     ],
     "require": {
-        "php": "^7.1",
+        "php": "^7.0",
         "php-http/httplug": "^2.0",
         "psr/http-client": "^1.0",
         "guzzlehttp/guzzle": "^6.0"

--- a/src/Client.php
+++ b/src/Client.php
@@ -30,7 +30,7 @@ final class Client implements HttpClient, HttpAsyncClient
      * throw exceptions on HTTP error status codes, or this adapter will violate PSR-18.
      * See also self::buildClient at the bottom of this class.
      */
-    public function __construct(?ClientInterface $client = null)
+    public function __construct(ClientInterface $client = null)
     {
         if (!$client) {
             $client = self::buildClient();


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets | none
| Documentation   | Support For PHP 7.0
| License         | MIT


#### What's in this PR?

Removes a single `?` in order to make this work on php 7.0

#### Why?

Need to use it in an old magento install that's currently tied to 7.0.

Already forked and using it, but pushing this back up in case anyone interested. The change is so tiny.

#### Checklist

- [x] Updated CHANGELOG.md to describe BC breaks / deprecations | new feature | bugfix

#### To Do

- [x] Update the CHANGELOG.md
