### PR TITLE
Guzzle 7.0 ready

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php": "^7.1",
         "php-http/httplug": "^2.0",
         "psr/http-client": "^1.0",
-        "guzzlehttp/guzzle": "^6.0"
+        "guzzlehttp/guzzle": "^6.0 || ^7.0"
     },
     "require-dev": {
         "ext-curl": "*",


### PR DESCRIPTION
| Q               | A
| --------------- | ---
| Bug fix?        | no
| New feature?    | no
| BC breaks?      | no
| Deprecations?   | no
| Related tickets |
| Documentation   |
| License         | MIT


#### What's in this PR?

Guzzle 7.0 is almost there, and as it's almost the same as Guzzle 6, the adapter should just support them both versions


#### Why?

To be able to use the new version via the adapter


#### Example Usage


#### Checklist

- [ ] Updated `CHANGELOG.md`

