### PR TITLE
note that guzzle6 is not compatible with PHP 8

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@
 
 **Guzzle 6 HTTP Adapter.**
 
+**Note**: Guzzle 6 is not compatible with PHP 8. If you need a PSR-18 client, use PSR-18 and Guzzle 7 which natively implements PSR-18. If you need the HTTPlug interfaces for asynchronous calls or for a system that still requires HTTPlug, use the [guzzle7-adapter](https://github.com/php-http/guzzle7-adapter/) instead of this repository.
 
 ## Install
 


### PR DESCRIPTION
People trying to upgrade to PHP 8 see that this repository is blocking them, because Guzzle 6 had a version constraint `>=5.5` which implies that it would support all future versions of PHP. however, this is not true, Guzzle 6 does not work in PHP 8.

Add a note to the readme to point to Guzzle 7.

close #77
